### PR TITLE
Fix Already registered command + Exiled Bump

### DIFF
--- a/TestingDummies/Commands/Dummy.cs
+++ b/TestingDummies/Commands/Dummy.cs
@@ -10,7 +10,7 @@ public class Dummy : ParentCommand
 
     public override string Command { get; } = "devdummy";
 
-    public override string[] Aliases { get; } = new[] { "DevDummy", "DEVDUMMY", "Devdummy" };
+    public override string[] Aliases { get; } = new string[0];
 
     public override string Description { get; } = "Parent command for handling Dev-Dummies.";
 

--- a/TestingDummies/Plugin.cs
+++ b/TestingDummies/Plugin.cs
@@ -10,12 +10,12 @@ public class Plugin : Plugin<Config>
 {
     public static Plugin Instance;
 
-    public override string Name => "Dev Dummies";
+    public override string Name => "TestingDummies";
     public override string Prefix => Name;
     public override string Author => "NotIntense";
     public override PluginPriority Priority => PluginPriority.Medium;
-    public override Version Version => new(2, 1, 7);
-    public override Version RequiredExiledVersion => new(7, 0, 0);
+    public override Version Version => new(2, 1, 8);
+    public override Version RequiredExiledVersion => new(8, 11, 0);
 
     public override void OnEnabled()
     {           

--- a/TestingDummies/TestingDummies.csproj
+++ b/TestingDummies/TestingDummies.csproj
@@ -31,23 +31,17 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\AppData\Roaming\EXILED\Plugins\dependencies\0Harmony.dll</HintPath>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>$(EXILED_REFERENCES)\Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>B:\SteamLibrary\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+    <Reference Include="Mirror">
+      <HintPath>$(EXILED_REFERENCES)\Mirror.dll</HintPath>
     </Reference>
-    <Reference Include="Mirror, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>B:\SteamLibrary\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\Mirror.dll</HintPath>
-    </Reference>
-    <Reference Include="Pooling, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>B:\SteamLibrary\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\Pooling.dll</HintPath>
+	<Reference Include="Pooling">
+      <HintPath>$(EXILED_REFERENCES)\Pooling.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -58,16 +52,13 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>B:\SteamLibrary\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AudioModule">
-      <HintPath>B:\SteamLibrary\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>$(EXILED_REFERENCES)\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>B:\SteamLibrary\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(EXILED_REFERENCES)\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>B:\SteamLibrary\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>$(EXILED_REFERENCES)\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -82,8 +73,8 @@
     <Compile Include="SpawningHandler\Spawn.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EXILED">
-      <Version>8.3.9</Version>
+    <PackageReference Include="EXILEDOFFICIAL">
+      <Version>8.11.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Hi i saw that the plugin was making an error while loading that the devdummy command is loaded multiple times
i just removed the aliases in the dummy.cs as they were only different with case and i think exiled might took them for the same.
Oh and i also modified the csproj to use the env var EXILED_REFERENCES and changed the package to EXILEDOFFICIAL